### PR TITLE
LIVY-356 Enabling LDAP authentication for Client to Server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
   - sudo apt-get -y install python3-pip python-dev
   - sudo apt-get -y install libkrb5-dev
   - sudo apt-get -y remove python-setuptools
-  - pip install --user --upgrade pip setuptools
-  - pip3 install --user --upgrade pip setuptools
+  - pip install --user --upgrade pip "setuptools < 36"
+  - pip3 install --user --upgrade pip "setuptools < 36"
   - pip install --user codecov cloudpickle
   - pip3 install --user cloudpickle
 

--- a/conf/livy-client.conf.template
+++ b/conf/livy-client.conf.template
@@ -55,7 +55,8 @@
 
 # Address for the RSC driver to connect back with it's connection info.
 # livy.rsc.launcher.address =
-# livy.rsc.launcher.port = -1
+# Port Range on which RPC will launch . Port range in inclusive of start and end port .
+# livy.rsc.launcher.port.range = 10000~10110
 
 # How long will the RSC wait for a connection for a Livy server before shutting itself down.
 # livy.rsc.server.idle-timeout = 10m

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -35,6 +35,9 @@
 # If livy should impersonate the requesting users when creating a new session.
 # livy.impersonation.enabled = true
 
+# Enable Logging queries
+# livy.server.query-logging.enabled = true
+
 # Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
 # time of sessions on YARN can be reduced.

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -19,6 +19,10 @@
 # What spark deploy mode Livy sessions should use.
 # livy.spark.deploy-mode =
 
+# Configure Livy server http request and response header size.
+# livy.server.request-header.size = 131072
+# livy.server.response-header.size = 131072
+
 # Enabled to check whether timeout Livy sessions should be stopped.
 # livy.server.session.timeout-check = true
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,11 @@
   </organization>
 
   <properties>
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>2.8.0</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <spark.version>1.6.2</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
+    <grouper-ws.version>2.3.0</grouper-ws.version>
     <httpclient.version>4.5.2</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.4.4</jackson.version>
@@ -230,7 +231,6 @@
       <version>${scalatra.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <dependencyManagement>
@@ -276,6 +276,18 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>edu.internet2.middleware.grouper</groupId>
+        <artifactId>grouper-ws</artifactId>
+        <version>${grouper-ws.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -51,8 +51,10 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     // Address for the RSC driver to connect back with it's connection info.
     LAUNCHER_ADDRESS("launcher.address", null),
+    LAUNCHER_PORT_RANGE("launcher.port.range", "10000~10010"),
+    // Setting up of this propety by user has no benefit. It is currently being used
+    // to pass  port information from ContextLauncher to RSCDriver
     LAUNCHER_PORT("launcher.port", -1),
-
     // How long will the RSC wait for a connection for a Livy server before shutting itself down.
     SERVER_IDLE_TIMEOUT("server.idle-timeout", "10m"),
 

--- a/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
+++ b/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
@@ -18,6 +18,8 @@
 package com.cloudera.livy.rsc.rpc;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
@@ -184,6 +186,31 @@ public class TestRpc {
     Future<TestMessage> call = client.call(outbound, TestMessage.class);
     TestMessage reply = call.get(10, TimeUnit.SECONDS);
     assertEquals(outbound.message, reply.message);
+  }
+
+  @Test
+  public void testPortRange() throws Exception {
+    String portRange = "a~b";
+    emptyConfig.set(LAUNCHER_PORT_RANGE, portRange);
+    try {
+      autoClose(new RpcServer(emptyConfig));
+    } catch (Exception ee) {
+      assertTrue(ee instanceof NumberFormatException);
+    }
+    portRange = "11000";
+    emptyConfig.set(LAUNCHER_PORT_RANGE, portRange);
+    try {
+      autoClose(new RpcServer(emptyConfig));
+    } catch (Exception ee) {
+      assertTrue(ee instanceof ArrayIndexOutOfBoundsException);
+    }
+    portRange = "11000~11110";
+    emptyConfig.set(LAUNCHER_PORT_RANGE, portRange);
+    String [] portRangeData = portRange.split("~");
+    int startPort = Integer.parseInt(portRangeData[0]);
+    int endPort = Integer.parseInt(portRangeData[1]);
+    RpcServer server = autoClose(new RpcServer(emptyConfig));
+    assertTrue(startPort <= server.getPort() && server.getPort() <= endPort);
   }
 
   private void transfer(Rpc serverRpc, Rpc clientRpc) {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -76,6 +76,17 @@
     </dependency>
 
     <dependency>
+      <groupId>edu.internet2.middleware.grouper</groupId>
+      <artifactId>grouper-ws</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -64,6 +64,7 @@ object LivyConf {
   val SERVER_PORT = Entry("livy.server.port", 8998)
 
   val UI_ENABLED = Entry("livy.ui.enabled", true)
+  val BATCH_ENABLED = Entry("livy.batch.enabled", true)
 
   val REQUEST_HEADER_SIZE = Entry("livy.server.request-header.size", 131072)
   val RESPONSE_HEADER_SIZE = Entry("livy.server.response-header.size", 131072)
@@ -91,6 +92,13 @@ object LivyConf {
   val LAUNCH_KERBEROS_KEYTAB = Entry("livy.server.launch.kerberos.keytab", null)
   val LAUNCH_KERBEROS_REFRESH_INTERVAL = Entry("livy.server.launch.kerberos.refresh-interval", "1h")
   val KINIT_FAIL_THRESHOLD = Entry("livy.server.launch.kerberos.kinit-fail-threshold", 5)
+
+  // Ldap properties
+  val AUTH_LDAP_URL = Entry("livy.server.auth.ldap.url", null)
+  val AUTH_LDAP_BASE_DN = Entry("livy.server.auth.ldap.base-dn", null)
+  val AUTH_LDAP_USERNAME_DOMAIN = Entry("livy.server.auth.ldap.username-domain", null)
+  val AUTH_LDAP_ENABLE_START_TLS = Entry("livy.server.auth.ldap.enable-start-tls", "false")
+  val AUTH_LDAP_SECURITY_AUTH = Entry("livy.server.auth.ldap.security-authentication", "simple")
 
   /**
    * Recovery mode of Livy. Possible values:

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -77,6 +77,8 @@ object LivyConf {
   val ACCESS_CONTROL_ENABLED = Entry("livy.server.access-control.enabled", false)
   val ACCESS_CONTROL_USERS = Entry("livy.server.access-control.users", null)
 
+  val QUERY_LOGGER_ENABLED = Entry("livy.server.query-logging.enabled", false)
+
   val SSL_KEYSTORE = Entry("livy.keystore", null)
   val SSL_KEYSTORE_PASSWORD = Entry("livy.keystore.password", null)
   val SSL_KEY_PASSWORD = Entry("livy.key-password", null)
@@ -193,6 +195,7 @@ object LivyConf {
     CSRF_PROTECTION.key -> DepConf("livy.server.csrf_protection.enabled", "0.4"),
     ACCESS_CONTROL_ENABLED.key -> DepConf("livy.server.access_control.enabled", "0.4"),
     ACCESS_CONTROL_USERS.key -> DepConf("livy.server.access_control.users", "0.4"),
+    QUERY_LOGGER_ENABLED.key -> DepConf("livy.server.query_logging.enabled", "0.4"),
     AUTH_KERBEROS_NAME_RULES.key -> DepConf("livy.server.auth.kerberos.name_rules", "0.4"),
     LAUNCH_KERBEROS_REFRESH_INTERVAL.key ->
       DepConf("livy.server.launch.kerberos.refresh_interval", "0.4"),

--- a/server/src/main/scala/com/cloudera/livy/server/ServletLoggerFilter.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/ServletLoggerFilter.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import java.io.IOException
+import java.util.Enumeration
+import javax.servlet._
+import javax.servlet.http.HttpServletRequest
+
+import edu.internet2.middleware.grouper.ws.j2ee.{HttpServletRequestCopier, ServletFilterLogger}
+
+import com.cloudera.livy.{LivyConf, Logging}
+
+/**
+ * Logs Requests Body
+ */
+class ServletLoggerFilter(livyConf: LivyConf) extends ServletFilterLogger with Logging {
+
+  import LivyConf._
+
+  override def init(filterConfig: FilterConfig): Unit = {}
+  override def destroy(): Unit = {}
+
+  @throws(classOf[IOException])
+  @throws(classOf[ServletException])
+  override def doFilter(servletRequest: ServletRequest,
+                        servletResponse: ServletResponse,
+                        chain: FilterChain): Unit = {
+    var requestCopier: HttpServletRequestCopier = new HttpServletRequestCopier(
+      servletRequest.asInstanceOf[HttpServletRequest])
+
+    try {
+      chain.doFilter(requestCopier, servletResponse)
+    } finally {
+      logRequestHandler(requestCopier)
+    }
+  }
+
+  /**
+   * Method that handles copying request
+   */
+  def logRequestHandler(servletRequest: HttpServletRequestCopier): Unit = {
+    try {
+      val requestCopier: HttpServletRequestCopier = servletRequest
+      requestCopier.finishReading()
+
+      var requestParams = new StringBuilder()
+      val enumeration = servletRequest.getParameterNames()
+      while (enumeration.hasMoreElements()) {
+        val name: String = enumeration.nextElement()
+        requestParams.append(name + " = " + servletRequest.getParameter(name) + ", ")
+      }
+
+      val httpRequest = servletRequest.asInstanceOf[HttpServletRequest]
+      logHttpRequest(httpRequest, requestCopier)
+    } catch {
+      case e: Exception => sys.error("Error in handling Request to be logged")
+    }
+  }
+
+  /**
+   * Method that logs request
+   */
+  def logHttpRequest(httpRequest: HttpServletRequest,
+                    requestCopier: HttpServletRequestCopier): Unit = {
+    try {
+      val ip = httpRequest.getRemoteAddr
+      val method = httpRequest.getMethod
+      val requestCopy = requestCopier.getCopy
+
+      if (method.contains("POST")) {
+        if (livyConf.get(AUTH_TYPE) != null) {
+          val userid = httpRequest.getRemoteUser
+          info("\nUser: " + userid.toString()
+                + "\nIP : " + ip.toString()
+                + "\n" + new String(requestCopy))
+        } else {
+          info("\nIP : " + ip.toString()
+                + "\n" + new String(requestCopy))
+        }
+      }
+    } catch {
+      case e: Exception => error("Error logging request", e)
+    }
+  }
+
+}

--- a/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.java
+++ b/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.server.auth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Properties;
+
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.StartTlsRequest;
+import javax.naming.ldap.StartTlsResponse;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceStability.Evolving;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
+import org.apache.hadoop.security.authentication.server.AuthenticationHandlerUtil;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Private
+@Evolving
+public class LdapAuthenticationHandlerImpl implements AuthenticationHandler {
+  private static Logger logger = LoggerFactory.getLogger(LdapAuthenticationHandlerImpl.class);
+  public static final String TYPE = "com.cloudera.livy.server.auth.LdapAuthenticationHandlerImpl";
+  public static final String SECURITY_AUTHENTICATION = "simple";
+  public static final String PROVIDER_URL = "ldap.providerurl";
+  public static final String BASE_DN = "ldap.basedn";
+  public static final String LDAP_BIND_DOMAIN = "ldap.binddomain";
+  public static final String ENABLE_START_TLS = "ldap.enablestarttls";
+  private String ldapDomain;
+  private String baseDN;
+  private String providerUrl;
+  private Boolean enableStartTls;
+  private Boolean disableHostNameVerification;
+
+  public LdapAuthenticationHandlerImpl() {
+  }
+
+  @VisibleForTesting
+  public void setEnableStartTls(Boolean enableStartTls) {
+    this.enableStartTls = enableStartTls;
+  }
+
+  @VisibleForTesting
+  public void setDisableHostNameVerification(Boolean disableHostNameVerification) {
+    this.disableHostNameVerification = disableHostNameVerification;
+  }
+
+  public String getType() {
+    return "ldap";
+  }
+
+  public void init(Properties config)
+      throws ServletException {
+    this.baseDN = config.getProperty(BASE_DN);
+    this.providerUrl = config.getProperty(PROVIDER_URL);
+    this.ldapDomain = config.getProperty(LDAP_BIND_DOMAIN);
+    this.enableStartTls = Boolean.valueOf(config.getProperty(ENABLE_START_TLS, "false"));
+    Preconditions.checkNotNull(this.providerUrl, "The LDAP URI can not be null");
+    if (this.enableStartTls.booleanValue()) {
+      String tmp = this.providerUrl.toLowerCase();
+      Preconditions.checkArgument(!tmp.startsWith("ldaps"), "Can not use ldaps and StartTLS option at the same time");
+    }
+  }
+
+  public void destroy() {
+  }
+
+  public boolean managementOperation(AuthenticationToken token, HttpServletRequest request,
+      HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    return true;
+  }
+
+  public AuthenticationToken authenticate(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    logger.debug("[authenticate] started");
+    logger.debug("[authenticate] Cookies: " + Arrays.toString(request.getCookies()));
+    AuthenticationToken token = null;
+    String authorization = request.getHeader("Authorization");
+    if (authorization != null && AuthenticationHandlerUtil.matchAuthScheme("Basic", authorization)) {
+      authorization = authorization.substring("Basic".length()).trim();
+      Base64 base64 = new Base64(0);
+      String[] credentials = (new String(base64.decode(authorization), StandardCharsets.UTF_8)).split(":", 2);
+      if (credentials.length == 2) {
+        token = this.authenticateUser(credentials[0], credentials[1]);
+        response.setStatus(200);
+      }
+    } else {
+      response.setHeader("WWW-Authenticate", "Basic");
+      response.setStatus(401);
+      if (authorization == null) {
+        logger.trace("Basic auth starting");
+      } else {
+        logger.warn("\'Authorization\' does not start with \'Basic\' :  {}", authorization);
+      }
+    }
+    logger.debug("[authenticate] ended");
+    return token;
+  }
+
+  private AuthenticationToken authenticateUser(String userName, String password)
+      throws AuthenticationException {
+    logger.debug("[authenticateUser] started");
+    if (userName != null && !userName.isEmpty()) {
+      if (!hasDomain(userName) && this.ldapDomain != null) {
+        userName = userName + "@" + this.ldapDomain;
+      }
+
+      if (password != null && !password.isEmpty() && password.getBytes(StandardCharsets.UTF_8)[0] != 0) {
+        String bindDN;
+        if (this.baseDN == null) {
+          bindDN = userName;
+        } else {
+          bindDN = "uid=" + userName + "," + this.baseDN;
+        }
+
+        if (this.enableStartTls.booleanValue()) {
+          this.authenticateWithTlsExtension(bindDN, password);
+        } else {
+          this.authenticateWithoutTlsExtension(bindDN, password);
+        }
+        logger.debug("[authenticateUser] ended");
+        return new AuthenticationToken(userName, userName, "ldap");
+      } else {
+        throw new AuthenticationException("Error validating LDAP user: a null or blank password has been provided");
+      }
+    } else {
+      throw new AuthenticationException("Error validating LDAP user: a null or blank username has been provided");
+    }
+  }
+
+  private void authenticateWithTlsExtension(String userDN, String password)
+      throws AuthenticationException {
+    InitialLdapContext ctx = null;
+    Hashtable env = new Hashtable();
+    env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
+    env.put("java.naming.provider.url", this.providerUrl);
+
+    try {
+      ctx = new InitialLdapContext(env, (Control[]) null);
+      StartTlsResponse ex = (StartTlsResponse) ctx.extendedOperation(new StartTlsRequest());
+      if (this.disableHostNameVerification.booleanValue()) {
+        ex.setHostnameVerifier(new HostnameVerifier() {
+          public boolean verify(String hostname, SSLSession session) {
+            return true;
+          }
+        });
+      }
+
+      ex.negotiate();
+      ctx.addToEnvironment("java.naming.security.authentication", SECURITY_AUTHENTICATION);
+      ctx.addToEnvironment("java.naming.security.principal", userDN);
+      ctx.addToEnvironment("java.naming.security.credentials", password);
+      ctx.lookup(userDN);
+      logger.debug("Authentication successful for {}", userDN);
+    } catch (IOException | NamingException var13) {
+      throw new AuthenticationException("Error validating LDAP user", var13);
+    } finally {
+      if (ctx != null) {
+        try {
+          ctx.close();
+        } catch (NamingException var12) {
+          ;
+        }
+      }
+    }
+  }
+
+  private void authenticateWithoutTlsExtension(String userDN, String password)
+      throws AuthenticationException {
+    Hashtable env = new Hashtable();
+    env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
+    env.put("java.naming.provider.url", this.providerUrl);
+    env.put("java.naming.security.authentication", SECURITY_AUTHENTICATION);
+    env.put("java.naming.security.principal", userDN);
+    env.put("java.naming.security.credentials", password);
+
+    try {
+      InitialDirContext e = new InitialDirContext(env);
+      e.close();
+      logger.debug("Authentication successful for {}", userDN);
+    } catch (NamingException var5) {
+      throw new AuthenticationException("Error validating LDAP user", var5);
+    }
+  }
+
+  private static boolean hasDomain(String userName) {
+    return indexOfDomainMatch(userName) > 0;
+  }
+
+  private static int indexOfDomainMatch(String userName) {
+    if (userName == null) {
+      return -1;
+    } else {
+      int idx = userName.indexOf(47);
+      int idx2 = userName.indexOf(64);
+      int endIdx = Math.min(idx, idx2);
+      if (endIdx == -1) {
+        endIdx = Math.max(idx, idx2);
+      }
+
+      return endIdx;
+    }
+  }
+}

--- a/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.scala
@@ -164,11 +164,11 @@ class LdapAuthenticationHandlerImpl() extends AuthenticationHandler {
       ctx.lookup(userDN)
       LdapAuthenticationHandlerImpl.logger.debug("Authentication successful for {}", userDN)
     } catch {
-      case var13@(_: IOException | _: NamingException) =>
-        throw new AuthenticationException("Error validating LDAP user", var13)
+      case exception@(_: IOException | _: NamingException) =>
+        throw new AuthenticationException("Error validating LDAP user", exception)
     } finally if (ctx != null) try ctx.close()
     catch {
-      case var12: NamingException =>
+      case exception: NamingException =>
     }
   }
 
@@ -186,8 +186,8 @@ class LdapAuthenticationHandlerImpl() extends AuthenticationHandler {
       e.close()
       LdapAuthenticationHandlerImpl.logger.debug("Authentication successful for {}", userDN)
     } catch {
-      case var5: NamingException =>
-        throw new AuthenticationException("Error validating LDAP user", var5)
+      case exception: NamingException =>
+        throw new AuthenticationException("Error validating LDAP user", exception)
     }
   }
 }

--- a/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/auth/LdapAuthenticationHandlerImpl.scala
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.server.auth
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.Properties
+import javax.naming.NamingException
+import javax.naming.directory.InitialDirContext
+import javax.naming.ldap.{Control, InitialLdapContext, StartTlsRequest, StartTlsResponse}
+import javax.net.ssl.{HostnameVerifier, SSLSession}
+import javax.servlet.ServletException
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import com.google.common.annotations.VisibleForTesting
+import org.apache.commons.codec.binary.Base64
+import org.apache.hadoop.security.authentication.client.AuthenticationException
+import org.apache.hadoop.security.authentication.server.{AuthenticationHandler, AuthenticationToken}
+import org.slf4j.{Logger, LoggerFactory}
+
+object LdapAuthenticationHandlerImpl {
+  val AUTHORIZATION_SCHEME: String = "Basic"
+  val logger: Logger = LoggerFactory.getLogger(classOf[LdapAuthenticationHandlerImpl])
+  val TYPE: String = "com.cloudera.livy.server.auth.LdapAuthenticationHandlerImpl"
+  val SECURITY_AUTHENTICATION: String = "simple"
+  val PROVIDER_URL: String = "ldap.providerurl"
+  val BASE_DN: String = "ldap.basedn"
+  val LDAP_BIND_DOMAIN: String = "ldap.binddomain"
+  val ENABLE_START_TLS: String = "ldap.enablestarttls"
+
+  private def hasDomain(userName: String) = indexOfDomainMatch(userName) > 0
+
+  private def indexOfDomainMatch(userName: String) = if (userName == null) -1
+  else {
+    val idx = userName.indexOf(47)
+    val idx2 = userName.indexOf(64)
+    var endIdx = Math.min(idx, idx2)
+    if (endIdx == -1) endIdx = Math.max(idx, idx2)
+    endIdx
+  }
+}
+
+class LdapAuthenticationHandlerImpl() extends AuthenticationHandler {
+  private var ldapDomain: String = null
+  private var baseDN: String = null
+  private var providerUrl: String = null
+  private var enableStartTls: Boolean = false
+  private var disableHostNameVerification: Boolean = false
+
+  @VisibleForTesting def setEnableStartTls(enableStartTls: Boolean):
+  Unit = this.enableStartTls = enableStartTls
+
+  @VisibleForTesting def setDisableHostNameVerification(disableHostNameVerification: Boolean):
+  Unit = this.disableHostNameVerification = disableHostNameVerification
+
+  def getType : String = "ldap"
+
+  @throws[ServletException]
+  def init(config: Properties): Unit = {
+    this.baseDN = config.getProperty(LdapAuthenticationHandlerImpl.BASE_DN)
+    this.providerUrl = config.getProperty(LdapAuthenticationHandlerImpl.PROVIDER_URL)
+    this.ldapDomain = config.getProperty(LdapAuthenticationHandlerImpl.LDAP_BIND_DOMAIN)
+    this.enableStartTls = config.getProperty(LdapAuthenticationHandlerImpl.ENABLE_START_TLS,
+      "false").toBoolean
+    require(this.providerUrl != null, "The LDAP URI can not be null")
+    if (this.enableStartTls.booleanValue) {
+      val tmp = this.providerUrl.toLowerCase
+      require(!tmp.startsWith("ldaps"), "Can not use ldaps and StartTLS option at the same time")
+    }
+  }
+
+  def destroy(): Unit = {
+  }
+
+  @throws[IOException]
+  @throws[AuthenticationException]
+  def managementOperation(token: AuthenticationToken, request: HttpServletRequest,
+                          response: HttpServletResponse) : Boolean = true
+
+  @throws[IOException]
+  @throws[AuthenticationException]
+  def authenticate(request: HttpServletRequest,
+                   response: HttpServletResponse): AuthenticationToken = {
+    var token: AuthenticationToken = null
+    var authorization = request.getHeader("Authorization")
+    if (authorization != null && authorization.regionMatches(true, 0,
+      LdapAuthenticationHandlerImpl.AUTHORIZATION_SCHEME, 0,
+      LdapAuthenticationHandlerImpl.AUTHORIZATION_SCHEME.length)) {
+      authorization = authorization.substring("Basic".length).trim
+      val base64 = new Base64(0)
+      val credentials = new String(base64.decode(authorization),
+        StandardCharsets.UTF_8).split(":", 2)
+      if (credentials.length == 2) {
+        LdapAuthenticationHandlerImpl.logger.debug("Authenticating [{}] user", credentials(0))
+        token = this.authenticateUser(credentials(0), credentials(1))
+        response.setStatus(200)
+      }
+    }
+    else {
+      response.setHeader("WWW-Authenticate", "Basic")
+      response.setStatus(401)
+      if (authorization == null) LdapAuthenticationHandlerImpl.logger.trace("Basic auth starting")
+      else LdapAuthenticationHandlerImpl.logger.warn("\'Authorization\' does not start " +
+        "with \'Basic\' :  {}", authorization)
+    }
+    token
+  }
+
+  @throws[AuthenticationException]
+  private def authenticateUser(userName: String, password: String) = if (
+    userName != null && !userName.isEmpty) {
+    var principle: String = userName
+    if (!LdapAuthenticationHandlerImpl.hasDomain(userName) &&
+      this.ldapDomain != null) {
+      principle = userName + "@" + this.ldapDomain
+    }
+    if (password != null && !password.isEmpty && password.getBytes(StandardCharsets.UTF_8) != 0) {
+      var bindDN: String = principle
+      if (this.baseDN != null) bindDN = "uid=" + principle + "," + this.baseDN
+      if (this.enableStartTls.booleanValue) this.authenticateWithTlsExtension(bindDN, password)
+      else this.authenticateWithoutTlsExtension(bindDN, password)
+      new AuthenticationToken(userName, userName, "ldap")
+    }
+    else throw new AuthenticationException(
+      "Error validating LDAP user: a null or blank password has been provided")
+  }
+  else throw new AuthenticationException(
+    "Error validating LDAP user: a null or blank username has been provided")
+
+  @throws[AuthenticationException]
+  private def authenticateWithTlsExtension(userDN: String, password: String) = {
+    var ctx: InitialLdapContext = null
+    val env = new util.Hashtable[String, String]
+    env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory")
+    env.put("java.naming.provider.url", this.providerUrl)
+    try {
+      ctx = new InitialLdapContext(env, null.asInstanceOf[Array[Control]])
+      val ex = ctx.extendedOperation(new StartTlsRequest).asInstanceOf[StartTlsResponse]
+      if (this.disableHostNameVerification.booleanValue) ex.setHostnameVerifier(
+        new HostnameVerifier() {
+        override def verify(hostname: String, session: SSLSession) = true
+      })
+      ex.negotiate
+      ctx.addToEnvironment("java.naming.security.authentication",
+        LdapAuthenticationHandlerImpl.SECURITY_AUTHENTICATION)
+      ctx.addToEnvironment("java.naming.security.principal", userDN)
+      ctx.addToEnvironment("java.naming.security.credentials", password)
+      ctx.lookup(userDN)
+      LdapAuthenticationHandlerImpl.logger.debug("Authentication successful for {}", userDN)
+    } catch {
+      case var13@(_: IOException | _: NamingException) =>
+        throw new AuthenticationException("Error validating LDAP user", var13)
+    } finally if (ctx != null) try ctx.close()
+    catch {
+      case var12: NamingException =>
+    }
+  }
+
+  @throws[AuthenticationException]
+  private def authenticateWithoutTlsExtension(userDN: String, password: String) = {
+    val env = new util.Hashtable[String, String]
+    env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory")
+    env.put("java.naming.provider.url", this.providerUrl)
+    env.put("java.naming.security.authentication",
+      LdapAuthenticationHandlerImpl.SECURITY_AUTHENTICATION)
+    env.put("java.naming.security.principal", userDN)
+    env.put("java.naming.security.credentials", password)
+    try {
+      val e = new InitialDirContext(env)
+      e.close()
+      LdapAuthenticationHandlerImpl.logger.debug("Authentication successful for {}", userDN)
+    } catch {
+      case var5: NamingException =>
+        throw new AuthenticationException("Error validating LDAP user", var5)
+    }
+  }
+}


### PR DESCRIPTION
Currently, Livy doesn't support LDAP Authentication from client(sparkmagic) to server(livy). We need to add LDAP authentication as that's preferable method due to security reasons. We won't be able to use Knox for this purpose. That is why I am raising this PR which contains LDAP authentication. 